### PR TITLE
Remove faulty comparison

### DIFF
--- a/Compare-NET-Objects/TypeComparers/DictionaryComparer.cs
+++ b/Compare-NET-Objects/TypeComparers/DictionaryComparer.cs
@@ -73,8 +73,6 @@ namespace KellermanSoftware.CompareNetObjects.TypeComparers
                 BreadCrumb = AddBreadCrumb(@params.Config, @params.BreadCrumb, propertyName),
             };
 
-            childParams.Result.CacheInProgress.Add(childParams, true);
-
             try
             {
                 RootComparer.Compare(childParams);


### PR DESCRIPTION
Adding the params to the cache in progress collection here caused the keys/values to be skipped while checking the dictionary.

The following tests should be added to the test-suite:

```cs
[Fact]
public void Dictionary_DifferentCount_IsDifferent()
{
    Dictionary<string, string> d1 = new Dictionary<string, string>();
    d1.Add("abc", "123");
    d1.Add("def", "213");

    Dictionary<string, string> d2 = new Dictionary<string, string>();
    d2.Add("abc", "89");

    AssertReflection.NotEqual(d1, d2);
}

[Fact]
public void Dictionary_DifferentEverything_IsDifferent()
{
    Dictionary<string, string> d1 = new Dictionary<string, string>();
    d1.Add("abc", "123");

    Dictionary<string, string> d2 = new Dictionary<string, string>();
    d2.Add("xyz", "89");

    AssertReflection.NotEqual(d1, d2);
}

[Fact]
public void Dictionary_DifferentKeys_IsDifferent()
{
    Dictionary<string, string> d1 = new Dictionary<string, string>();
    d1.Add("abc", "123");

    Dictionary<string, string> d2 = new Dictionary<string, string>();
    d2.Add("xyz", "123");

    AssertReflection.NotEqual(d1, d2);
}

[Fact]
public void Dictionary_DifferentValues_IsDifferent()
{
    Dictionary<string, string> d1 = new Dictionary<string, string>();
    d1.Add("abc", "123");

    Dictionary<string, string> d2 = new Dictionary<string, string>();
    d2.Add("abc", "89");

    AssertReflection.NotEqual(d1, d2);
}
```